### PR TITLE
fix: use draftId and respective endpoints

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,1 @@
-CMS_HOST=
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -17,11 +17,3 @@ of a post as it will appear when published live on `/news`.
   docker compose build
   docker compose up -d
   ```
-
-> [!NOTE]
-> Need to set the following environment variables
-
-**Environment Variables**
-
-- `CMS_HOST`: The Hashnode Publication URL
-- `PORT`: The port to run the server on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,5 @@ services:
     ports:
       - ${PORT:-3000}:3000
     environment:
-      - CMS_HOST=${CMS_HOST}
       - NODE_ENV=production
     restart: unless-stopped

--- a/src/fetch-content.js
+++ b/src/fetch-content.js
@@ -3,50 +3,44 @@ import { request, gql } from 'graphql-request';
 const endpoint = 'https://gql.hashnode.com/';
 
 const query = gql`
-  query GetDraftFromPublication($host: String!, $slug: String!) {
-    publication(host: $host) {
-      post(slug: $slug) {
+  query GetDraft($id: ObjectId!) {
+    draft(id: $id) {
+      id
+      slug
+      author {
         id
-        slug
-        author {
-          id
-          username
-          name
-          bio {
-            text
-          }
-          profilePicture
-          socialMediaLinks {
-            website
-            twitter
-            facebook
-          }
-          location
+        username
+        name
+        bio {
+          text
         }
-        title
-        tags {
-          id
-          name
-          slug
+        profilePicture
+        socialMediaLinks {
+          website
+          twitter
+          facebook
         }
-        brief
-        readTimeInMinutes
-        coverImage {
-          url
-          attribution
-        }
-        content {
-          html
-        }
-        publishedAt
-        updatedAt
+        location
       }
+      title
+      # tagsV2 {
+      #   __typename
+      # }
+      readTimeInMinutes
+      coverImage {
+        url
+        attribution
+      }
+      content {
+        html
+      }
+      updatedAt
     }
   }
 `;
 
-export async function fetchContent(host, slug) {
-  const variables = { host, slug };
-  const { publication } = await request(endpoint, query, variables);
-  return publication.post;
+export async function fetchContent(id) {
+  const variables = { id };
+  const { draft } = await request(endpoint, query, variables);
+  return draft;
 }


### PR DESCRIPTION
This PR switches to using `draftId` and the draft endpoint for the query which is logically better than the previous implementation. This makes it so that the final preview service looks like so: `http://localhost:3000/66450fc26022973650d240`. I also added some more validations while I was at it.
