### PR TITLE
feat: show previews for both unpublished drafts and published posts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,2 @@
 PORT=3000
+HASHNODE_HOST=host_from_hashnode_dashboard

--- a/src/fetch-content.js
+++ b/src/fetch-content.js
@@ -2,45 +2,74 @@ import { request, gql } from 'graphql-request';
 
 const endpoint = 'https://gql.hashnode.com/';
 
-const query = gql`
+const commonFields = `
+  id
+  title
+  slug
+  author {
+    id
+    username
+    name
+    bio {
+      text
+    }
+    profilePicture
+    socialMediaLinks {
+      website
+      twitter
+      facebook
+    }
+    location
+  }
+  coverImage {
+    url
+  }
+  content {
+    html
+  }
+  readTimeInMinutes
+  updatedAt
+`;
+
+const draftQuery = gql`
   query GetDraft($id: ObjectId!) {
     draft(id: $id) {
-      id
-      slug
-      author {
-        id
-        username
-        name
-        bio {
-          text
-        }
-        profilePicture
-        socialMediaLinks {
-          website
-          twitter
-          facebook
-        }
-        location
-      }
-      title
-      # tagsV2 {
-      #   __typename
-      # }
-      readTimeInMinutes
-      coverImage {
-        url
-        attribution
-      }
-      content {
-        html
-      }
-      updatedAt
+      ${commonFields}
     }
   }
 `;
 
-export async function fetchContent(id) {
-  const variables = { id };
-  const { draft } = await request(endpoint, query, variables);
-  return draft;
+const postQuery = gql`
+  query GetPost($host: String!, $slug: String!) {
+    publication(host: $host) {
+      post(slug: $slug) {
+        ${commonFields}
+        tags {
+          id
+          name
+          slug
+        }
+        publishedAt
+      }
+    }
+  }
+`;
+
+export async function fetchContent(idOrSlug) {
+  const isValidObjectId =
+    idOrSlug.length === 24 && /^[0-9a-fA-F]{24}$/.test(idOrSlug);
+
+  if (isValidObjectId) {
+    const { draft } = await request(endpoint, draftQuery, { id: idOrSlug });
+
+    return draft;
+  }
+
+  const HASHNODE_HOST = process.env.HOST || 'handle.hashnode.dev';
+  const { publication } = await request(endpoint, postQuery, {
+    host: HASHNODE_HOST,
+    slug: idOrSlug
+  });
+
+  return publication.post;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Currently we can preview unpublished posts with the object id in the URL of the Hashnode editor (https://hashnode.com/draft/<object-id>) and using it as a URL param for this service (https://preview.freecodecamp.org/<object-id>).

This PR also enables us to preview published posts via the slug (https://preview.freecodecamp.org/<published-post-slug>). Unfortunately we have to use the `publication()... post(slug)` query here because, once a post is published on Hashnode, the URL for that post on Hashnode is updated from an object id to some other kind of hash. Since we're dealing with two different kinds of URL params now, I had to remove the middleware that checks for valid object ids and use that regex test elsewhere.

To test this PR, first set the `HASHNODE_HOST` environment variable in the `.env` file to the fCC publication's hostname in the Hashnode dashboard, then start the service.

And here are a couple of links for testing:
- http://localhost:3000/665c7da21928a247e621dc3a
- http://localhost:3000/build-a-youtube-clone-with-flutter-firebase-and-riverpod