### PR TITLE
fix: add fCC CDN as possible scriptSrc

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -38,7 +38,12 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        scriptSrc: ["'self'", "'unsafe-inline'", 'https://webembeds.com'],
+        scriptSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          'https://webembeds.com',
+          'https://cdn.freecodecamp.org'
+        ],
         styleSrc: [
           "'self'",
           "'unsafe-inline'",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR adds the fCC CDN as a possible `scriptSrc` for Helmet, which will allow DayJS to load properly and render relative dates.

Here are a couple of screenshots for verification:

Before change:

![image](https://github.com/freeCodeCamp/hashnode-preview/assets/2051070/cf5feaa3-9fd5-45d8-8c9d-b579e0fddc07)

After change:

![image](https://github.com/freeCodeCamp/hashnode-preview/assets/2051070/5652a53c-7803-4b9a-83d0-b1d16f087d9f)