### PR TITLE
feat: enable MathJax for previews

### DIFF
--- a/src/fetch-content.js
+++ b/src/fetch-content.js
@@ -35,6 +35,18 @@ const draftQuery = gql`
   query GetDraft($id: ObjectId!) {
     draft(id: $id) {
       ${commonFields}
+      tags: tagsV2 {
+        __typename
+          ... on Tag {
+          id
+          name
+          slug
+        }
+        ... on DraftBaseTag {
+          name
+          slug
+        }
+      }
     }
   }
 `;

--- a/src/templates/index.njk
+++ b/src/templates/index.njk
@@ -1918,6 +1918,11 @@
           order: 2;
         }
       }
+      p:has(mjx-container.MathJax) {
+        display: inline-block;
+        max-width: 100%;
+        overflow: auto;
+      }
       .under-header-content .author-profile-image,
       .under-header-content .avatar-wrapper {
         z-index: 10;
@@ -2658,6 +2663,20 @@
       });
     </script>
     {# END: /assets/js/client-dayjs.js #}
+
+    {# START: block mathjax #}
+    {% for tag in post.tags %}
+      {% if ((tag.slug | lower) === 'mathjax') %}
+        <script
+          type="text/javascript"
+          id="MathJax-script"
+          data-test-label="mathjax-script"
+          src="https://cdn.freecodecamp.org/news-assets/mathjax/3.2.2/tex-mml-chtml.min.js"
+          defer
+        ></script>
+      {% endif %}
+    {% endfor %}
+    {# END: block mathjax #}
 
     <link
       rel="icon"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR should enable MathJax for previews of drafts and published posts. We only have an unpublished draft with some math in at the moment: http://localhost:3000/665c7da21928a247e621dc3a

Once https://github.com/freeCodeCamp/news/pull/907 has been merged, I can move one of Zaira's recent posts back over to Hashnode and use that to test MathJax in previews for published posts.