### PR TITLE
fix: missing MathJax resources

### DIFF
--- a/src/config/helmet.js
+++ b/src/config/helmet.js
@@ -21,9 +21,15 @@ export default {
         'https://api.spotify.com',
         'https://api.github.com',
         'https://api.twitter.com',
-        'https://api.codesandbox.io'
+        'https://api.codesandbox.io',
+        'https://cdn.freecodecamp.org'
       ],
-      fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com'],
+      fontSrc: [
+        "'self'",
+        'data:',
+        'https://fonts.gstatic.com',
+        'https://cdn.freecodecamp.org'
+      ],
       objectSrc: ["'none'"],
       upgradeInsecureRequests: [],
       frameSrc: [

--- a/src/templates/post.njk
+++ b/src/templates/post.njk
@@ -2673,7 +2673,7 @@ else
       type="text/javascript"
       id="MathJax-script"
       data-test-label="mathjax-script"
-      src="https://cdn.freecodecamp.org/news-assets/mathjax/3.2.2/tex-mml-chtml.min.js"
+      src="https://cdn.freecodecamp.org/news-assets/mathjax/3.2.2/es5/tex-mml-chtml.js"
       defer
     ></script>
       {% endif %}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Related to https://github.com/freeCodeCamp/cdn/pull/266

<!-- Feel free to add any additional description of changes below this line -->
This updates News to use the new main MathJax script in the `es5` directory, which also contains previously missing resources like a11y scripts and fonts.

This also updates the Helmet config to allow scripts and fonts from the CDN repo.