### PR TITLE
fix: allow Cloudflare scripts to enable lazy loading for images and gifs

### DIFF
--- a/src/config/helmet.js
+++ b/src/config/helmet.js
@@ -7,6 +7,8 @@ export default {
         "'unsafe-inline'",
         'https://webembeds.com',
         'https://platform.twitter.com',
+        'ajax.cloudflare.com',
+        'static.cloudflareinsights.com',
         'https://cdn.freecodecamp.org'
       ],
       scriptSrcAttr: [


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Larger images and gifs are lazy loaded via Cloudflare when the preview is loaded for mobile sized devices. These changes allow for Cloudflare Mirage and Insights scripts to load to enable lazy loading and other analytics.

Here's a draft id to test these changes with: 67040054cf21e80f25add597