### PR TITLE
chore: bump Node version require pnpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install -g pnpm \
+RUN npm install -g pnpm@10 \
   && pnpm install --prod
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
@@ -7,7 +7,7 @@ RUN npm install -g pnpm \
 
 COPY . .
 
-FROM node:20-alpine
+FROM node:22-alpine
 WORKDIR /app
 
 COPY --from=builder /app .

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "description": "Post preview service for Hashnode",
   "type": "module",
   "engines": {
-    "node": ">=20",
-    "npm": ">=10"
+    "node": ">=22",
+    "pnpm": ">=10"
   },
   "scripts": {
     "start": "node --watch --trace-warnings ./src/server.js"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "node": ">=22",
     "pnpm": ">=10"
   },
+  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
   "scripts": {
     "start": "node --watch --trace-warnings ./src/server.js"
   },


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR bumps the version of Node up to v22 throughout the project. It also includes a couple of other minor fixes, like requiring pnpm rather than npm in `package.json`, and fixes the casing for `AS` in `Dockerfile`.