### PR TITLE
fix: remove slug from draft queries

### DIFF
--- a/src/fetch-content.js
+++ b/src/fetch-content.js
@@ -5,7 +5,6 @@ const endpoint = 'https://gql.hashnode.com/';
 const commonFields = `
   id
   title
-  slug
   author {
     id
     username
@@ -56,6 +55,7 @@ const postBySlugQuery = gql`
     publication(host: $host) {
       post(slug: $slug) {
         ${commonFields}
+        slug
         tags {
           id
           name
@@ -71,6 +71,7 @@ const postByIdQuery = gql`
   query GetPostById($id: ID!) {
     post(id: $id) {
       ${commonFields}
+      slug
       tags {
         id
         name


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This removes the slug from common fields since they might not exist on drafts and moves them to those specific to published posts. This should fix previews for drafts, at least recent ones.

Here's an id for a recent draft for testing: 69b2026a6c896b0519d19e2a