### PR TITLE
fix: draft preview authorization

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 PORT=3000
 HASHNODE_HOST=host_from_hashnode_dashboard
+HASHNODE_TOKEN=personal_access_token_from_hashnode_dashboard

--- a/README.md
+++ b/README.md
@@ -5,6 +5,25 @@
 This uses Hashnode's GraphQL API and Nunjucks to render an approximate preview
 of a post as it will appear when published live on `/news`.
 
+## Environment variables
+
+Copy `.env.sample` to `.env` and fill in the values:
+
+| Variable         | Description                                                                                                                                                                                                                             |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`           | Port the server listens on (defaults to `3000`).                                                                                                                                                                                        |
+| `HASHNODE_HOST`  | The publication host from the Hashnode dashboard (e.g. `fcc.hashnode.dev`).                                                                                                                                                             |
+| `HASHNODE_TOKEN` | A Hashnode [personal access token](https://hashnode.com/settings/developer). **Required to preview drafts** — Hashnode's `draft` query is authenticated and returns `UNAUTHENTICATED` without it. Published posts work without a token. |
+
+> [!NOTE]
+> A personal access token is tied to the account that created it and can expire
+> or be revoked. If draft previews start failing with an `UNAUTHENTICATED`
+> error, regenerate the token and update `HASHNODE_TOKEN`.
+>
+> For the production app, the token is kept in the team password manager and set
+> as an encrypted environment variable in the DigitalOcean App Platform settings.
+> Update it in both places when rotating.
+
 ## Development
 
 > [!WARNING]

--- a/src/fetch-content.js
+++ b/src/fetch-content.js
@@ -77,6 +77,13 @@ function isNotFoundError(error) {
   );
 }
 
+// A missing or expired HASHNODE_TOKEN surfaces as `extensions.code === 'UNAUTHENTICATED'`.
+function isAuthError(error) {
+  if (!(error instanceof ClientError)) return false;
+  const errors = error.response?.errors ?? [];
+  return errors.some(e => e?.extensions?.code === 'UNAUTHENTICATED');
+}
+
 export async function fetchContent(idOrSlug) {
   const isValidObjectId =
     idOrSlug.length === 24 && /^[0-9a-fA-F]{24}$/.test(idOrSlug);
@@ -84,13 +91,28 @@ export async function fetchContent(idOrSlug) {
 
   try {
     if (isValidObjectId) {
+      // Drafts are private, so Hashnode requires an authenticated request.
+      const draftHeaders = process.env.HASHNODE_TOKEN
+        ? { Authorization: process.env.HASHNODE_TOKEN }
+        : undefined;
+
       // Try draft first; published posts share the 24-char hex id shape.
       try {
-        const response = await request(endpoint, draftQuery, {
-          id: idOrSlug
-        });
+        const response = await request(
+          endpoint,
+          draftQuery,
+          { id: idOrSlug },
+          draftHeaders
+        );
         if (response.draft) return response.draft;
       } catch (error) {
+        if (isAuthError(error)) {
+          logger.error(
+            'Hashnode rejected the draft request as unauthenticated. ' +
+              'Check that HASHNODE_TOKEN is set and the personal access token is still valid.'
+          );
+          throw error;
+        }
         if (!isNotFoundError(error)) throw error;
       }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
We received a report about draft previews not working. It seems to be an authorization issue, and may require a PAT header now when fetching drafts.

I signed into the Hashnode account tied to the dev email address and got the most recent PAT from there. I created a secure note in 1Password with the tokens listed there for reference. I also added the most recent token as a secret to the Digital Ocean app. It should get picked up once this is reviewed and merged.